### PR TITLE
Updated English messages

### DIFF
--- a/scripting/SimpleGDPRCompliance.sp
+++ b/scripting/SimpleGDPRCompliance.sp
@@ -68,7 +68,7 @@ public int MenuHandler(Menu menu, MenuAction action, int param1, int param2)
 		else if(StrEqual(info, "#refuse"))
 		{
 			SetClientCookie(param1, g_hGDPRCookie, "0");
-			KickClient(param1, "You must accept the GDPR conditions to use this server");
+			KickClient(param1, "You must accept the GDPR notification to use this server");
 		}
 		delete menu;
     }

--- a/translations/SimpleGDPRCompliance.phrases.txt
+++ b/translations/SimpleGDPRCompliance.phrases.txt
@@ -2,7 +2,7 @@
 {
 	"Content"
 	{
-		"en" 	"GDPR Compliance Notice\n \nThis server tracks your IP address and SteamID,\nand uses cookies to improve your experience.\n \nYou must accept these conditions to use this server.\n \n"
+		"en" 	"--- European Union GDPR Compliance Notice ---\n \nThis server logs your SteamID and IP address to enforce bans,\nand sets a cookie so you will only see this notification once.\n \nYou must accept these conditions to play on this server.\n \n"
 		"fr" 	"Avis sur la RGPD\n \nCe serveur utilise des cookies, sauvegarde IP et SteamID\nPour améliorer votre expérience.\n \nVous devez accepter cela pour jouer dessus."
 		"hu" 	"GDPR Beleegyezés értesítés\n \nEz a szerver követi az IP címedet és a SteamID-et,\nés sütiket használ hogy javítsa az élményedet.\n \nEl kell fogadnod ezeket a körülményeket ahhoz hogy használhasd ezt a szervert.\n \n"
 	}

--- a/translations/SimpleGDPRCompliance.phrases.txt
+++ b/translations/SimpleGDPRCompliance.phrases.txt
@@ -2,7 +2,7 @@
 {
 	"Content"
 	{
-		"en" 	"--- European Union GDPR Compliance Notice ---\n \nThis server logs your SteamID and IP address to enforce bans,\nand sets a cookie so you will only see this notification once.\n \nYou must accept these conditions to play on this server.\n \n"
+		"en" 	"--- European Union GDPR Compliance Notice ---\n \nThis server logs your SteamID and IP address to enforce bans,\nand sets a cookie so you will only see this notification once.\n \nYou must accept this notification to use this server.\n \n"
 		"fr" 	"Avis sur la RGPD\n \nCe serveur utilise des cookies, sauvegarde IP et SteamID\nPour améliorer votre expérience.\n \nVous devez accepter cela pour jouer dessus."
 		"hu" 	"GDPR Beleegyezés értesítés\n \nEz a szerver követi az IP címedet és a SteamID-et,\nés sütiket használ hogy javítsa az élményedet.\n \nEl kell fogadnod ezeket a körülményeket ahhoz hogy használhasd ezt a szervert.\n \n"
 	}


### PR DESCRIPTION
I found a large percentage of players would reject the notification because it was too vague.  I don't blame them.  As a result, I changed the English translation to be more specific about why the SteamID and IP address are being logged (to enforce bans) and why a cookie is created (so the notification is only seen once).  I also made a tiny change to the kick message so it uses the word "notice" rather than "conditions".  By the way, you should consider changing the kick message to use translations too.